### PR TITLE
EG-19 fixed busy wait in endpoint.go

### DIFF
--- a/core/clients/types/endpoint.go
+++ b/core/clients/types/endpoint.go
@@ -10,16 +10,13 @@ import (
 type Endpoint struct {}
 
 func(e Endpoint) Monitor(params EndpointParams, ch chan string) {
-	check := time.Now()
 	for true {
-		if time.Now().After(check) {
-			data, err := consulclient.GetServiceEndpoint(params.ServiceKey)
-			if err != nil {
-				fmt.Fprintln(os.Stdout, err.Error())
-			}
-			url := fmt.Sprintf("http://%s:%v%s", data.Address, data.Port, params.Path)
-			ch <- url
-			check = time.Now().Add(time.Second * time.Duration(15))
+		data, err := consulclient.GetServiceEndpoint(params.ServiceKey)
+		if err != nil {
+			fmt.Fprintln(os.Stdout, err.Error())
 		}
+		url := fmt.Sprintf("http://%s:%v%s", data.Address, data.Port, params.Path)
+		ch <- url
+		time.Sleep(15000 * time.Millisecond)
 	}
 }


### PR DESCRIPTION
Signed-off-by: Tom Fleming <tom@iotechsys.com>

EG-19, fixed for high CPU utilisation observed in core-data and core-command when consul is active. Fixed busy wait in endpoint.go