### PR TITLE
EG-20 fix to ensure command URL is set correctly 

### DIFF
--- a/core/command/init.go
+++ b/core/command/init.go
@@ -66,5 +66,6 @@ func Init(conf ConfigurationStruct, l logger.LoggingClient, useConsul bool) {
 
 	mdc = metadata.NewDeviceClient(params, types.Endpoint{})
 	params.Path = conf.MetaCommandPath
+	params.Url = conf.MetaCommandURL
 	cc = metadata.NewCommandClient(params, types.Endpoint{})
 }


### PR DESCRIPTION
Signed-off-by: Tom Fleming <tom@iotechsys.com>

Fix for EG-20. Commands could not be issued with consul was not running. URL must be set correctly, as the full path is stored.